### PR TITLE
Use “-o” to specify the output of “cpp”

### DIFF
--- a/src/patfonts/Rules.mk
+++ b/src/patfonts/Rules.mk
@@ -63,7 +63,7 @@ $(d)/fonts.cmxs: $(LIBFONTS_CMX)
 
 $(d)/unicodeRanges/unicode_ranges_cpp.ml: $(d)/unicodeRanges/unicode_ranges.ml
 	$(ECHO) "[CPP] $@"
-	$(Q)$(PATFONTS_CPP) $< $@
+	$(Q)$(PATFONTS_CPP) -o $@ $<
 
 $(d)/UnicodeRanges.ml: $(d)/unicodeRanges/unicode_ranges_cpp.ml $(d)/unicodeRanges/unicode
 	$(ECHO) "[GEN] $@"


### PR DESCRIPTION
Some implementations of `cpp` (e.g., the one shipped with `clang`) need the output file to be specified using the `-o` flag instead of by position.