### PR TITLE
Port to imagelib ≥ 20191011

### DIFF
--- a/drivers/DriverGL/DriverGL.ml
+++ b/drivers/DriverGL/DriverGL.ml
@@ -728,7 +728,7 @@ let output' ?(structure:structure={name="";raw_name=[];metadata=[];tags=[];
         try GlTex.bind_texture ~target:`texture_2d
               (Hashtbl.find win.imageCache i)
         with Not_found ->
-          let image = ImageLib.openfile i.image_file in
+          let image = ImageLib_unix.openfile i.image_file in
           let w =Image.(image.width) in
           let h =Image.(image.height) in
           let raw = Raw.create `ubyte ~len:(4*w*h) in

--- a/drivers/DriverImage/DriverImage.ml
+++ b/drivers/DriverImage/DriverImage.ml
@@ -85,7 +85,7 @@ let output ?(structure:structure=empty_structure) pages fileName=
         done;
         let fname = Filename.concat dirname (filename' fileName page state) in
         Printf.fprintf stderr "Writing %s\n" fname;
-        ImageLib.writefile fname image) states) pages;
+        ImageLib_unix.writefile fname image) states) pages;
     ()
   in
 

--- a/drivers/Pdf/Pdf.ml
+++ b/drivers/Pdf/Pdf.ml
@@ -601,7 +601,7 @@ let output ?(structure:structure=empty_structure) pages fname =
 
             if !pageImages<>[] then (
               List.iter Image.(fun (obj,_,i)->
-                let image=ImageLib.openfile i.image_file in
+                let image = ImageLib_unix.openfile i.image_file in
                 let w=image.width and h=image.height in
                 let bits_per_component =
                   if image.max_val <= 255 then 8 else 16 in

--- a/patobook/patobook.txp
+++ b/patobook/patobook.txp
@@ -43,7 +43,7 @@ Pierre-Etienne Meunier
     bB (fun env0->
       let w4,h4=Util.a4 in
       let img="titlepato.png" in
-      let wesci,hesci = ImageLib.size img in
+      let wesci, hesci = ImageLib_unix.size img in
       let wesc = float_of_int wesci and hesc = float_of_int hesci in
       let alpha=0.2 in
 

--- a/patoraw/RawContent.ml
+++ b/patoraw/RawContent.ml
@@ -48,7 +48,7 @@ type image =
   ; image_pixel_height : int }
 
 let image filename =
-  let (w,h) = ImageLib.size filename in
+  let (w,h) = ImageLib_unix.size filename in
   { image_file   = filename
   ; image_x      = 0.0
   ; image_y      = 0.0

--- a/patoraw/dune
+++ b/patoraw/dune
@@ -2,4 +2,4 @@
   (name patoraw)
   (public_name patoline.patoraw)
   (modules :standard)
-  (libraries dynlink imagelib patutil patfonts))
+  (libraries dynlink imagelib-unix patutil patfonts))

--- a/typography/Document.ml
+++ b/typography/Document.ml
@@ -1167,7 +1167,7 @@ let video ?scale:(scale=0.) ?width:(width=0.) ?height:(height=0.) ?offset:(offse
       let _=Sys.command (Printf.sprintf "ffmpeg -i %s -t 1 -r 1 %s-%%d.png" imageFile tmp) in
       ()
     );
-  let w,h = ImageLib.size (tmp^"-1.png") in
+  let w,h = ImageLib_unix.size (tmp^"-1.png") in
   let fw,fh=
     if width=0. then
       if height=0. then


### PR DESCRIPTION
A few high-level functions from the “imagelib” library now
belong to a new “imagelib-unix” library.

NB: the installation instructions may need to be updated too.